### PR TITLE
Throw error in case of invalid WebID profiles

### DIFF
--- a/src/algorithm/retrieveWebidTrustedOidcIssuers.ts
+++ b/src/algorithm/retrieveWebidTrustedOidcIssuers.ts
@@ -24,17 +24,21 @@ export async function retrieveWebidTrustedOidcIssuers(
   const store = new Store();
   const issuer: string[] = [];
 
-  return new Promise((resolve) => {
-    store.import(quadStream).on("end", () => {
-      store
-        .match(
-          DataFactory.namedNode(webid),
-          DataFactory.namedNode("http://www.w3.org/ns/solid/terms#oidcIssuer")
-        )
-        .on("data", (quad: Quad) => {
-          issuer.push(quad.object.value);
-        })
-        .on("end", () => resolve(issuer));
-    });
+  return new Promise((resolve, reject) => {
+    store
+      .import(quadStream)
+      .on("end", () => {
+        store
+          .match(
+            DataFactory.namedNode(webid),
+            DataFactory.namedNode("http://www.w3.org/ns/solid/terms#oidcIssuer")
+          )
+          .on("data", (quad: Quad) => {
+            issuer.push(quad.object.value);
+          })
+          .on("error", reject)
+          .on("end", () => resolve(issuer));
+      })
+      .on("error", reject);
   });
 }

--- a/test/algorithm/retrieveWebidTrustedOidcIssuers.test.ts
+++ b/test/algorithm/retrieveWebidTrustedOidcIssuers.test.ts
@@ -57,4 +57,12 @@ describe("The retrieveWebidTrustedOidcIssuers function", () => {
       await retrieveWebidTrustedOidcIssuers("x");
     }).rejects.toThrow(WebidDereferencingError);
   });
+
+  it("Throws when there is an error parsing the WebID", async () => {
+    mockRdfDereferencer("very invalid turtle");
+
+    await expect(async () => {
+      await retrieveWebidTrustedOidcIssuers("x");
+    }).rejects.toThrow('Unexpected "very" on line 1.');
+  });
 });


### PR DESCRIPTION
Relevant for https://github.com/solid/community-server/issues/999

I don't think the nested error event can ever trigger but no reason not to have it just to be sure.

With this solution an `Error` object gets thrown, not an internal error type. Let me know if this is fine or if you want a new internal error type for this situation.

Feel free to either adapt this PR yourself or let me know which changes are needed.