### PR TITLE
Replace split by more specific assumptions

### DIFF
--- a/src/algorithm/verifyDpopProofHttpUri.ts
+++ b/src/algorithm/verifyDpopProofHttpUri.ts
@@ -10,8 +10,8 @@ import { HttpUriVerificationError } from "../error";
  * @param htu The DPoP proof htu parameter
  */
 export function verifyDpopProofHttpUri(uri: string, htu: string): void {
-  const actual = uri.split("?")[0].split("#")[0];
-  if (actual !== htu) {
-    throw new HttpUriVerificationError(actual, htu);
+  const rawUri = uri.replace(/[?#].*/, "");
+  if (htu !== rawUri) {
+    throw new HttpUriVerificationError(rawUri, htu);
   }
 }

--- a/src/algorithm/verifySolidAccessToken.ts
+++ b/src/algorithm/verifySolidAccessToken.ts
@@ -30,10 +30,11 @@ export async function verifySolidAccessToken(
 ): Promise<SolidAccessTokenPayload> {
   // Extract access token value from authorization header
   const accessTokenValue = authorization.header.replace(/^(DPoP|Bearer) /, "");
+  const accessTokenParts = accessTokenValue.split(".");
 
   // Decode Solid access token payload
   const accessTokenPayload: unknown = decodeBase64UrlEncodedJson(
-    accessTokenValue.split(".")[1]
+    accessTokenParts[1]
   );
 
   // Verify the Solid access token includes all required claims
@@ -82,7 +83,7 @@ export async function verifySolidAccessToken(
   const accessToken = {
     header: protectedHeader,
     payload,
-    signature: accessTokenValue.split(".")[2],
+    signature: accessTokenParts[2],
   };
 
   isSolidAccessToken(accessToken);

--- a/src/error/HttpUriVerificationError.ts
+++ b/src/error/HttpUriVerificationError.ts
@@ -1,7 +1,7 @@
 export class HttpUriVerificationError extends Error {
   constructor(actual: string, expected: string) {
     super(
-      `The DPoP proof htu parameter doesn't match the HTTP request URI without query and fragment parts.\nActual: ${actual}\nExpected: ${expected}`
+      `The DPoP proof htu parameter must be the HTTP request URI without query and fragment parts.\nActual: ${actual}\nExpected: ${expected}`
     );
   }
 }

--- a/test/algorithm/verifyDpopProof.test.ts
+++ b/test/algorithm/verifyDpopProof.test.ts
@@ -123,6 +123,23 @@ describe("verifyDpopProof()", () => {
     ).resolves.not.toThrow();
   });
 
+  it("throws on invalid DPoP header", async () => {
+    await expect(
+      verifyDpopProof(
+        "invalid",
+        {
+          payload: {
+            cnf: { jkt: "0ZcOCORZNYy-DWpqq30jZyJGHTN0d2HglBV3uiguA4I" },
+          },
+        } as any as SolidAccessToken,
+        "",
+        "GET",
+        "https://resource.example.org/protectedresource",
+        () => false
+      )
+    ).rejects.toThrow();
+  });
+
   it("throws on invalid ath claim", async () => {
     (jwtVerify as jest.Mock).mockResolvedValueOnce({
       payload: dpopPayloadWithAth,

--- a/test/algorithm/verifySolidAccessToken.test.ts
+++ b/test/algorithm/verifySolidAccessToken.test.ts
@@ -76,6 +76,20 @@ describe("verifySolidAccessToken()", () => {
     ).toStrictEqual(bearerToken.payload);
   });
 
+  it("throws on invalid header", async () => {
+    await expect(
+      verifySolidAccessToken({
+        header: "invalid",
+        issuers: () =>
+          Promise.resolve([
+            "https://example.com/abc",
+            "https://example.com/issuer",
+          ]),
+        keySet: retrieveAccessTokenIssuerKeySet,
+      })
+    ).rejects.toThrow();
+  });
+
   it("throws on non conforming access token", async () => {
     const wrongProtocolToken = {
       header: accessToken.header,


### PR DESCRIPTION
Following https://github.com/solid/access-token-verifier/issues/15#issuecomment-981607690, I am replacing `split` usage by more specific regular expressions.