### PR TITLE
Fix base 64 token segment parsing

### DIFF
--- a/src/algorithm/parseSolidAuthorizationHeader.ts
+++ b/src/algorithm/parseSolidAuthorizationHeader.ts
@@ -1,6 +1,6 @@
-import { SolidAuthorizationHeaderParsingError } from "../error/SolidAuthorizationHeaderParsingError";
 import type { SolidJwt } from "../type";
 import { verifyAuthenticationScheme } from "./verifyAuthenticationScheme";
+import { verifyBase64TokenSegments } from "./verifyBase64TokenSegments";
 import { verifyJwtSegments } from "./verifyJwtSegments";
 
 /**
@@ -13,7 +13,9 @@ export function parseSolidAuthorizationHeader(
   authorizationHeader: string
 ): SolidJwt {
   const [match, joseHeader, jwsPayload, jwsSignature] =
-    /^(?:DPoP|Bearer) +(\w+)\.(\w+)\.(\w+)$/i.exec(authorizationHeader) ?? [];
+    /^(?:DPoP|Bearer) +([\w\-~+/]+)\.([\w\-~+/]+)\.([\w\-~+/]+)(?:=+)?$/i.exec(
+      authorizationHeader
+    ) ?? [];
 
   if (!match) {
     // Verify the authentication scheme is supported
@@ -22,7 +24,8 @@ export function parseSolidAuthorizationHeader(
     // Verify the token is composed of the right number of segments
     verifyJwtSegments(authorizationHeader);
 
-    throw new SolidAuthorizationHeaderParsingError(authorizationHeader);
+    // Verify each segment is a Base 64 encoded token
+    verifyBase64TokenSegments(authorizationHeader);
   }
 
   return {

--- a/src/algorithm/verifyBase64TokenSegments.ts
+++ b/src/algorithm/verifyBase64TokenSegments.ts
@@ -15,7 +15,7 @@ export function verifyBase64TokenSegments(authorizationHeader: string): void {
 
   segments.forEach((x, key) => {
     // Last segments can end with 0 or more "="
-    if (Object.is(segments.length - 1, key)) {
+    if (key === segments.length - 1) {
       if (!/^[\w\-~+/]+(=+)?$/.test(x)) {
         throw new Base64TokenSegmentError(x);
       }

--- a/src/algorithm/verifyBase64TokenSegments.ts
+++ b/src/algorithm/verifyBase64TokenSegments.ts
@@ -1,0 +1,26 @@
+import { Base64TokenSegmentError } from "../error/Base64TokenSegmentError";
+
+/**
+ * Verify each segment is a Base 64 token
+ *
+ * > b64token = 1*( ALPHA / DIGIT / "-" / "." / "_" / "~" / "+" / "/" ) *"="
+ * > -- https://datatracker.ietf.org/doc/html/rfc6750#section-2.1
+ *
+ * @param authorizationHeader The authorization header used for the request.
+ */
+export function verifyBase64TokenSegments(authorizationHeader: string): void {
+  const segments = authorizationHeader
+    .replace(/^(DPoP|Bearer) +/i, "")
+    .split(".");
+
+  segments.forEach((x, key) => {
+    // Last segments can end with 0 or more "="
+    if (Object.is(segments.length - 1, key)) {
+      if (!/^[\w\-~+/]+(=+)?$/.test(x)) {
+        throw new Base64TokenSegmentError(x);
+      }
+    } else if (!/^[\w\-~+/]+$/.test(x)) {
+      throw new Base64TokenSegmentError(x);
+    }
+  });
+}

--- a/src/error/Base64TokenSegmentError.ts
+++ b/src/error/Base64TokenSegmentError.ts
@@ -1,0 +1,7 @@
+export class Base64TokenSegmentError extends Error {
+  constructor(actual: string) {
+    super(
+      `Token segments should be Base 64 encoded strings.\nActual: ${actual}\nExpected: A base 64 encoded token segment`
+    );
+  }
+}

--- a/src/error/SolidAuthorizationHeaderParsingError.ts
+++ b/src/error/SolidAuthorizationHeaderParsingError.ts
@@ -1,7 +1,0 @@
-export class SolidAuthorizationHeaderParsingError extends Error {
-  constructor(actual: string) {
-    super(
-      `The Authorization header parsing failed.\nActual: ${actual}\nExpected: A DPoP or Bearer authentication scheme and a JWT composed of URL-safe parts (base64 url-encoded values) separated by period ('.') characters`
-    );
-  }
-}

--- a/test/unit/algorithm/parseSolidAuthorizationHeader.test.ts
+++ b/test/unit/algorithm/parseSolidAuthorizationHeader.test.ts
@@ -1,11 +1,18 @@
 import { parseSolidAuthorizationHeader } from "../../../src/algorithm/parseSolidAuthorizationHeader";
 import { AuthenticationSchemeVerificationError } from "../../../src/error/AuthenticationSchemeVerificationError";
+import { Base64TokenSegmentError } from "../../../src/error/Base64TokenSegmentError";
 import { JwtStructureError } from "../../../src/error/JwtStructureError";
-import { SolidAuthorizationHeaderParsingError } from "../../../src/error/SolidAuthorizationHeaderParsingError";
 
 describe("parseSolidAuthorizationHeader()", () => {
   it("doesn't throw when the authentication scheme is supported", () => {
     expect(parseSolidAuthorizationHeader("dpop x.y.z")).toStrictEqual({
+      authenticationScheme: "DPoP",
+      joseHeader: "x",
+      jwsPayload: "y",
+      jwsSignature: "z",
+      value: "x.y.z",
+    });
+    expect(parseSolidAuthorizationHeader("dpop x.y.z===")).toStrictEqual({
       authenticationScheme: "DPoP",
       joseHeader: "x",
       jwsPayload: "y",
@@ -26,9 +33,9 @@ describe("parseSolidAuthorizationHeader()", () => {
     }).toThrow(JwtStructureError);
   });
 
-  it("throws when the JWT contains unsafe characters", () => {
+  it("throws when the base 64 segments contain illegal characters", () => {
     expect(() => {
-      parseSolidAuthorizationHeader("dpop x.y.z§");
-    }).toThrow(SolidAuthorizationHeaderParsingError);
+      parseSolidAuthorizationHeader("dpop x.y.z$==");
+    }).toThrow(Base64TokenSegmentError);
   });
 });

--- a/test/unit/algorithm/verifyBase64TokenSegments.test.ts
+++ b/test/unit/algorithm/verifyBase64TokenSegments.test.ts
@@ -1,0 +1,30 @@
+import { verifyBase64TokenSegments } from "../../../src/algorithm/verifyBase64TokenSegments";
+import { Base64TokenSegmentError } from "../../../src/error/Base64TokenSegmentError";
+
+describe("verifyBase64TokenSegments()", () => {
+  it("doesn't throw on base 64 token segments", () => {
+    expect(() => verifyBase64TokenSegments("dpop  x.y.z")).not.toThrow();
+    expect(() => verifyBase64TokenSegments("dpop  x/.y./z==")).not.toThrow();
+    expect(() =>
+      verifyBase64TokenSegments("dpop  x.y.A0-_~+/==")
+    ).not.toThrow();
+    expect(() =>
+      verifyBase64TokenSegments("A0-_~+/.A0-_~+/.A0-_~+/==")
+    ).not.toThrow();
+  });
+
+  it("throws when on illegal characters in base 64 token segments", () => {
+    expect(() => verifyBase64TokenSegments("dpop  x=.y.z")).toThrow(
+      Base64TokenSegmentError
+    );
+    expect(() => verifyBase64TokenSegments("x.\\y.z==")).toThrow(
+      Base64TokenSegmentError
+    );
+    expect(() => verifyBase64TokenSegments("x.y^.A0-_~+/==")).toThrow(
+      Base64TokenSegmentError
+    );
+    expect(() =>
+      verifyBase64TokenSegments("A0-_~+/.A0-_~+/.A0-$_~+/==")
+    ).toThrow(Base64TokenSegmentError);
+  });
+});


### PR DESCRIPTION
The new Regex for token parsing was too restrictive.

See also: https://datatracker.ietf.org/doc/html/rfc6750#section-2.1

cc @jaxoncreed 